### PR TITLE
Refactor to clarify use of the main (erosion) timestep and the hydro-model timestep

### DIFF
--- a/include/catchmentmodel/LSDCatchmentModel.hpp
+++ b/include/catchmentmodel/LSDCatchmentModel.hpp
@@ -168,7 +168,7 @@ public:
 
   void set_loop_cycle();
 
-  double courant_friedrichs_lewy_condition()
+  double courant_friedrichs_lewy_condition();
 
   /// @brief Calculates and sets the maximum time step (also the erosion timestep)
   void set_maximum_timestep();

--- a/include/catchmentmodel/LSDCatchmentModel.hpp
+++ b/include/catchmentmodel/LSDCatchmentModel.hpp
@@ -170,9 +170,11 @@ public:
 
   double courant_friedrichs_lewy_condition()
 
+  /// @brief Calculates and sets the maximum time step (also the erosion timestep)
   void set_maximum_timestep();
 
-  double set_local_timefactor();
+  /// @brief calculates the timestep for the hydro/flow model
+  double get_flow_timestep();
 
   void increment_counters();
 
@@ -328,12 +330,12 @@ public:
 
   /// @brief Calculates the amount of runoff on a grid-cell from the rainfall
   /// timeseries input
-  void catchment_water_input_and_hydrology( double local_time_factor);
+  void catchment_water_input_and_hydrology( double flow_timestep);
 
-  /// @brief Overloaded function is for when using the fully distriuted/complex
+  /// @brief Overloaded function is for when u<a href="#datastructures">Understanding sing the fully distriuted/complex
   /// rainfall patterns option in the model. Takes a reference to the runoffGrid
   /// object.
-  void catchment_water_input_and_hydrology( double local_time_factor, runoffGrid& runoff);
+  void catchment_water_input_and_hydrology( double flow_timestep, runoffGrid& runoff);
 
   /// @brief Gets the number of catchment cells that have water input to them
   /// @detail Calculates which cells contain a discharge greater than MIN_Q

--- a/include/catchmentmodel/LSDCatchmentModel.hpp
+++ b/include/catchmentmodel/LSDCatchmentModel.hpp
@@ -168,7 +168,9 @@ public:
 
   void set_loop_cycle();
 
-  void set_global_timefactor();
+  double courant_friedrichs_lewy_condition()
+
+  void set_maximum_timefactor();
 
   double set_local_timefactor();
 

--- a/include/catchmentmodel/LSDCatchmentModel.hpp
+++ b/include/catchmentmodel/LSDCatchmentModel.hpp
@@ -170,7 +170,7 @@ public:
 
   double courant_friedrichs_lewy_condition()
 
-  void set_maximum_timefactor();
+  void set_maximum_timestep();
 
   double set_local_timefactor();
 
@@ -486,7 +486,7 @@ private:
   double lateral_cross_channel_smoothing = 0.0001;
   double lateral_constant=0.0000002;
 
-  double time_factor = 1;
+  double time_step = 1;
   std::vector<double> j, jo, j_mean, old_j_mean, new_j_mean;
 
   /// TOPMODEL 'm'

--- a/src/catchmentmodel/LSDCatchmentModel.cpp
+++ b/src/catchmentmodel/LSDCatchmentModel.cpp
@@ -2690,7 +2690,7 @@ void LSDCatchmentModel::catchment_water_input_and_hydrology( double flow_timeste
     } while (time_1 < cycle);
   }
 
-  calchydrograph(time_1 - cycle, runoff;
+  calchydrograph(time_1 - cycle, runoff);
 }
 
 // Fully distributed TOPMODEL

--- a/src/catchmentmodel/LSDCatchmentModel.cpp
+++ b/src/catchmentmodel/LSDCatchmentModel.cpp
@@ -64,7 +64,6 @@
 #ifndef LSDCatchmentModel_CPP
 #define LSDCatchmentModel_CPP
 
-#define COURANT_FRIEDRICH_LEVY_CONDITION = courant_number * (DX / std::sqrt(gravity * (maxdepth)))
 
 using namespace LSDUtils;
 

--- a/src/catchmentmodel/LSDCatchmentModel.cpp
+++ b/src/catchmentmodel/LSDCatchmentModel.cpp
@@ -1198,7 +1198,7 @@ void LSDCatchmentModel::set_inputoutput_diff()
 
 double LSDCatchmentModel::courant_friedrichs_lewy_condition()
 {
-  return courant_number * (DX / std::sqrt(gravity * (maxdepth)))
+  return courant_number * (DX / std::sqrt(gravity * (maxdepth)));
 }
 
 // Sets the maximum timestep for the current iteration

--- a/src/catchmentmodel/LSDCatchmentModel.cpp
+++ b/src/catchmentmodel/LSDCatchmentModel.cpp
@@ -1218,7 +1218,7 @@ void LSDCatchmentModel::set_maximum_timestep()
   // step exceeds the CFL (Courant Friedrich Levy) condition, then reduce the 
   // time step to the CFL-prescribed value.
   if (input_output_difference > in_out_difference_allowed && time_step > \
-     (courant_friedrichs_lewy_condition())
+     (courant_friedrichs_lewy_condition()))
   {
     time_step = courant_friedrichs_lewy_condition();
   }
@@ -2306,7 +2306,7 @@ void LSDCatchmentModel::water_flux_out()
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 void LSDCatchmentModel::flow_route()
-
+{
   double flow_timestep = get_flow_timestep();
 
   #pragma omp parallel for

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,6 @@
 ///
 /// HAIL-CAESAR
 /// (The High Performance Architecture Independent LISFLOOD CAESAR model)
-/// The Catchment Hydrogeomorphology Model v1.0 (CHM1)
 ///
 /// This is the main function for running the HAIL-CAESAR model.
 ///
@@ -136,7 +135,7 @@ int main(int argc, char *argv[])
     // If this value meets a user-defined threshold, the time step is
     // automatically increased.
     simulation.set_inputoutput_diff();
-    simulation.set_global_timefactor();
+    simulation.set_maximum_timestep();
     simulation.increment_counters();
 
     // Hydrological and flow routing processes


### PR DESCRIPTION
Previously the terms `global_time_factor` and `local_time_factor` were being used, originally named after the port from dvalters/CAESAR-Lisflood@eb544c035e1ad0cee1c7c6d05707cd40f5f548ef. The model has two timesteps, one for the hydro/flow-routing model and one for the erosion model, which is also the "general" timestep (Originally it was just called `time_factor` in CL). "Global" and "local" are confusing nomenclature. There is nothing spatially local about the local timestep - it is in fact the timestep for the hydro model/flow routing etc.

From the Coulthard paper (2013):

> In CAESAR-Lisflood there are two controls on the model time step. First, for the flow model the CFL condition (Equation 3) and second, for the erosion and deposition components (from CAESAR). The time step is determined by the amount of erosion and deposition in a cell (Coulthard et al., 2002; Van de Wiel et al., 2007).

> This leads to situations where the flow model time step is smaller than the erosion/deposition time step (for example during low flows when there is little or no erosion/deposition) and conversely where the erosion/deposition time step is much smaller than the flow model time step (for example during high low events where there is significant erosion/deposition). Therefore, CAESAR-Lisflood automatically chooses the smaller time step from either component.

#### Equation 3 from Coulthard et al (2013)

<a href="https://www.codecogs.com/eqnedit.php?latex=\Delta&space;t_{max}&space;=&space;\alpha&space;\frac{\Delta&space;x}{\sqrt{gh}}" target="_blank"><img src="https://latex.codecogs.com/gif.latex?\Delta&space;t_{max}&space;=&space;\alpha&space;\frac{\Delta&space;x}{\sqrt{gh}}" title="\Delta t_{max} = \alpha \frac{\Delta x}{\sqrt{gh}}" /></a>

This changeset refactors the CFL calculation into its own function to avoid code duplication, and renames the time_step variables to more sensible names. 

The general time_step variable is also used as the erosion time step. (I think this is slightly confusing still and may return for further refactoring.)