### PR TITLE
Fix deprecated fixtures behaviour

### DIFF
--- a/test/basic_kga_tests.py
+++ b/test/basic_kga_tests.py
@@ -31,7 +31,7 @@ def timeseries(filename, col_number):
     return out_data
 
 
-@pytest.fixture
+# @pytest.fixture
 def rasters_params():
     """
     Pytest fixture that reads in paths containing results/KGAs

--- a/test/input_data/boscastle/boscastle_input_data/boscastle_test_72hr_50m_u.params
+++ b/test/input_data/boscastle/boscastle_input_data/boscastle_test_72hr_50m_u.params
@@ -11,7 +11,7 @@
 read_fname:                    boscastle_square_50m      # TOP-LAYER DEM NAME, NO EXTENSION PLEASE
 dem_read_extension:            asc                    # OPTIONS ARE asc (ASCII) ONLY, OTHER FORMATS NOT YET SUPPORTED - SORRY!
 dem_write_extension:           asc                    # OPTIONS ARE asc, flt, OR bil (BIL EXPERIMENTAL)
-read_path:                     ./input_data/boscastle_input_data/  
+read_path:                     ./input_data/boscastle/boscastle_input_data/  
 write_path:                    ./results/boscastle50m_72_u/
 write_fname:                   boscastle_50m_72hr_u.dat         # CATCHMENT HYDROGRAPH AND SEDS OUTPUT TIMESERIES FILE (NOT RASTERS)
 timeseries_save_interval:      5                      # IN MODEL MINUTES


### PR DESCRIPTION
# Summary

You cannot call fixtures directly in the latest version of Pytest. This means decorated functions as fixtures cannot be called when calling parameterised functions that have fixture functions as input arguments.

**Solution**:  

Make the fixture a standard function.