### PR TITLE
Spatial mannings

### DIFF
--- a/include/catchmentmodel/LSDCatchmentModel.hpp
+++ b/include/catchmentmodel/LSDCatchmentModel.hpp
@@ -603,6 +603,7 @@ private:
   TNT::Array2D<double> sand2;
   TNT::Array2D<double> grain;
   TNT::Array2D<double> elev_diff;
+  TNT::Array2D<double> spat_var_mannings;
 
   TNT::Array2D<int> index;
   TNT::Array2D<int> down_scan;
@@ -702,6 +703,7 @@ private:
   bool bedrock_layer_on = false;
   bool lateral_erosion_on = false;
   bool spatially_var_rainfall = false;
+  bool spatially_var_mannings = false;
   bool graindata_from_file = false;
 
   bool spatially_complex_rainfall = false;
@@ -734,6 +736,7 @@ private:
   std::string elevdiff_fname = "";
   std::string raingrid_fname = "";
   std::string runoffgrid_fname = "";
+  std::string mannings_fname = "";
 
   bool DEBUG_print_cycle_on = false;
   bool DEBUG_write_raingrid = false;

--- a/src/catchmentmodel/LSDCatchmentModel.cpp
+++ b/src/catchmentmodel/LSDCatchmentModel.cpp
@@ -258,8 +258,8 @@ void LSDCatchmentModel::load_data()
     }
     try
     {
-      hydroindexR.read_ascii_raster_integers(MANNINGS_FILENAME);
-      TNT::Array2D<int> raw_rfarea = manningsR.get_RasterData_int();
+      hydroindexR.read_ascii_raster(MANNINGS_FILENAME);
+      TNT::Array2D<double> raw_rfarea = manningsR.get_RasterData_dbl();
       // Solves padding issues
       for (unsigned i=0; i<imax; i++)
       {

--- a/src/catchmentmodel/LSDCatchmentModel.cpp
+++ b/src/catchmentmodel/LSDCatchmentModel.cpp
@@ -1362,6 +1362,8 @@ void LSDCatchmentModel::initialise_arrays()
   vel_dir = TNT::Array3D<double> (imax+2, jmax+2, 9, 0.0);
   Vsusptot = TNT::Array2D<double> (imax+2,jmax+2, 0.0);
 
+  spat_var_mannings = TNT::Array2D<double> (imax+2, jmax+2, 0.0);
+
   //inpoints=new int[10,2];
   //inputpointsarray = new bool[xmax + 2, ymax + 2];
 

--- a/src/catchmentmodel/LSDCatchmentModel.cpp
+++ b/src/catchmentmodel/LSDCatchmentModel.cpp
@@ -2671,6 +2671,11 @@ void LSDCatchmentModel::flow_route()
       inc++;
       if (elev[x][y] > -9999) // to stop moving water in to -9999's on elev
       {
+        // SPATIAL MANNINGS
+        if spatial_mannings_opt 
+        {
+            mannings = spat_var_mannings[x][y];
+        }
         // routing in x direction
         if ((water_depth[x][y] > 0 || water_depth[x - 1][y] > 0) \
           && elev[x - 1][y] > -9999)

--- a/test/input_data/caersws/Caersws.params
+++ b/test/input_data/caersws/Caersws.params
@@ -16,7 +16,9 @@ timeseries_save_interval:      60
 # SUPPLEMENTARY FILES
 #====================
 # REMEMBER TO SPECIFY A BEDROCK DEM FILE IF YOU TURN THIS ON
-spatial_mannings_dem_file:         caersws_mannings.asc
+# ditto for Mannings Spatial, Spatial rainfall, Hyrdoindex file etc.
+
+# spatial_mannings_dem_file:         caersws_mannings.asc
 
 # NUMERICAL
 #===========

--- a/test/input_data/caersws/Caersws.params
+++ b/test/input_data/caersws/Caersws.params
@@ -16,6 +16,7 @@ timeseries_save_interval:      60
 # SUPPLEMENTARY FILES
 #====================
 # REMEMBER TO SPECIFY A BEDROCK DEM FILE IF YOU TURN THIS ON
+spatial_mannings_dem_file:         caersws_mannings.asc
 
 # NUMERICAL
 #===========
@@ -56,6 +57,7 @@ evaporation_rate:              0.0         # NOT YET IMPLEMENTED
 courant_number:                0.7         # NO LOWER THAN 3 PLEASE, MAX AROUND 0.7 - NUMERICAL STABILITY CONTROL
 froude_num_limit:              0.8         # CONTROLS FLOW BETWEEN CELLS PER TIME STEP (SEE DOCS)
 mannings_n:                    0.04        # SEE LITERATURE FOR GUIDANCE
+spatially_variable_mannings_on:     no          # REQUIRES DEM FILE ABOVE IF YES
 hflow_threshold:               0.001      # IN METRES, DETERMINES IF HORIZ. FLOW CALCULATED
 
 # REACH MODE HYDROLOGY


### PR DESCRIPTION
## Summary

Implements an option to set the Manning's n value based on reading in a DEM with corresponding n values for each cell.

Inputs:

 - A dem in ASCII format of the spatially distributed Manning's n values. It must be the same shape and size as your elevation/topo DEM
 - Parameter file must have the following options set:
(See Caersws.params for latest example)

```
spatial_mannings_dem_file:         caersws_mannings.asc
...
spatially_variable_mannings_on:     yes
```

This will override any value set in the `mannings_n` value and ignore the default value of 0.4
 
Can be applied in reach or catchment mode.